### PR TITLE
Updating thomsonreuters/jwks-rsa-java with latest from auth0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## [0.12.0](https://github.com/auth0/jwks-rsa-java/tree/0.12.0) (2020-06-25)
+[Full Changelog](https://github.com/auth0/jwks-rsa-java/compare/0.11.0...0.12.0)
+
+**Added**
+- Add NetworkException, docs and tests [\#89](https://github.com/auth0/jwks-rsa-java/pull/89) ([lbalmaceda](https://github.com/lbalmaceda))
+
 ## [0.11.0](https://github.com/auth0/jwks-rsa-java/tree/0.11.0) (2020-02-14)
 [Full Changelog](https://github.com/auth0/jwks-rsa-java/compare/0.10.0...0.11.0)
 

--- a/README.md
+++ b/README.md
@@ -11,14 +11,14 @@
 <dependency>
     <groupId>com.auth0</groupId>
     <artifactId>jwks-rsa</artifactId>
-    <version>0.11.0</version>
+    <version>0.12.0</version>
 </dependency>
 ```
 
 ### Gradle
 
 ```gradle
-implementation 'com.auth0:jwks-rsa:0.11.0'
+implementation 'com.auth0:jwks-rsa:0.12.0'
 ```
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -113,17 +113,17 @@ There are certain scenarios in which this library can fail. Read below to unders
 This error may arise when the hosted JSON Web Key set (JWKS) file doesn't represent a valid set of keys, or is empty. They are raised as a `SigningKeyNotFoundException`. The cause would need to be inspected in order to understand the specific failure reason. 
 
 #### Network error
-There's a special case for Network errors. These errors represent timeouts, invalid URLs, or a faulty internet connection. They may occur when fetching the keys from the given URL. They are raised as a `SigningKeyNotFoundException` instance with an `IOException` cause. 
+There's a special case for Network errors. These errors represent timeouts, invalid URLs, or a faulty internet connection. They may occur when fetching the keys from the given URL. They are raised as a `NetworkException` instance. 
 
-If you need to detect this scenario, check that the cause matches an `IOException`.
+If you need to detect this scenario, make sure to check it before the catch of `SigningKeyNotFoundException`.
 
 ```java
 try {
     // ...
+} catch (NetworkException e) {
+    // Network error
 } catch (SigningKeyNotFoundException e) {
-    if (e.getCause() instanceof IOException){
-        // Network error
-    }
+    // Key is invalid or not found
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -106,6 +106,44 @@ JwkProvider provider = new JwkProviderBuilder("https://samples.auth0.com/")
 Jwk jwk = provider.get("{kid of the signing key}"); //throws Exception when not found or can't get one
 ```
 
+## Error handling
+There are certain scenarios in which this library can fail. Read below to understand what to expect and how to handle the errors.
+
+### Missing JSON Web Key
+This error may arise when the hosted JSON Web Key set (JWKS) file doesn't represent a valid set of keys, or is empty. They are raised as a `SigningKeyNotFoundException`. The cause would need to be inspected in order to understand the specific failure reason. 
+
+#### Network error
+There's a special case for Network errors. These errors represent timeouts, invalid URLs, or a faulty internet connection. They may occur when fetching the keys from the given URL. They are raised as a `SigningKeyNotFoundException` instance with an `IOException` cause. 
+
+If you need to detect this scenario, check the cause matches an `IOException`.
+
+```java
+try {
+    // ...
+} catch (SigningKeyNotFoundException e) {
+    if (e.getCause() instanceof IOException){
+        // Network error
+    }
+}
+```
+
+### Unsupported JSON Web Key
+When the received key is not of type **RSA** or the exponent and modulus values representing it are wrong, a `InvalidPublicKeyException` will be raised.
+
+### Rate limits
+When using a rate-limited provider, an `RateLimitReachedException` error might be raised when the limit is breached. The instance can help determine how long to wait until the next call would be available. 
+
+```java
+try {
+    // ...
+} catch (RateLimitReachedException e) {
+    long waitTime = e.getAvailableIn()
+    // wait until available
+}
+```  
+
+#### 
+ 
 ## What is Auth0?
 
 Auth0 helps you to:

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ This error may arise when the hosted JSON Web Key set (JWKS) file doesn't repres
 #### Network error
 There's a special case for Network errors. These errors represent timeouts, invalid URLs, or a faulty internet connection. They may occur when fetching the keys from the given URL. They are raised as a `SigningKeyNotFoundException` instance with an `IOException` cause. 
 
-If you need to detect this scenario, check the cause matches an `IOException`.
+If you need to detect this scenario, check that the cause matches an `IOException`.
 
 ```java
 try {
@@ -128,10 +128,10 @@ try {
 ```
 
 ### Unsupported JSON Web Key
-When the received key is not of type **RSA** or the exponent and modulus values representing it are wrong, a `InvalidPublicKeyException` will be raised.
+When the received key is not of type **RSA** or the exponent and modulus values representing it are wrong, an `InvalidPublicKeyException` will be raised.
 
 ### Rate limits
-When using a rate-limited provider, an `RateLimitReachedException` error might be raised when the limit is breached. The instance can help determine how long to wait until the next call would be available. 
+When using a rate-limited provider, a `RateLimitReachedException` error might be raised when the limit is breached. The instance can help determine how long to wait until the next call would be available. 
 
 ```java
 try {

--- a/README.md
+++ b/README.md
@@ -142,8 +142,6 @@ try {
 }
 ```  
 
-#### 
- 
 ## What is Auth0?
 
 Auth0 helps you to:

--- a/src/main/java/com/auth0/jwk/NetworkException.java
+++ b/src/main/java/com/auth0/jwk/NetworkException.java
@@ -1,0 +1,9 @@
+package com.auth0.jwk;
+
+@SuppressWarnings("WeakerAccess")
+public class NetworkException extends SigningKeyNotFoundException {
+
+    public NetworkException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/com/auth0/jwk/UrlJwkProvider.java
+++ b/src/main/java/com/auth0/jwk/UrlJwkProvider.java
@@ -109,7 +109,7 @@ public class UrlJwkProvider implements JwkProvider {
                 return reader.readValue(inputStream);
             }
         } catch (IOException e) {
-            throw new SigningKeyNotFoundException("Cannot obtain jwks from url " + url.toString(), e);
+            throw new NetworkException("Cannot obtain jwks from url " + url.toString(), e);
         }
     }
 

--- a/src/test/java/com/auth0/jwk/UrlJwkProviderTest.java
+++ b/src/test/java/com/auth0/jwk/UrlJwkProviderTest.java
@@ -253,4 +253,19 @@ public class UrlJwkProviderTest {
         //Request Headers assertions
         verify(urlConnection).setRequestProperty("Accept", "application/json");
     }
+
+    @Test
+    public void shouldFailWithNetworkError() throws Exception {
+        expectedException.expect(NetworkException.class);
+        URLConnection urlConnection = mock(URLConnection.class);
+
+        // Although somewhat of a hack, this approach gets the job done - this method can
+        // only be called once per virtual machine, but that is sufficient for now.
+        URL.setURLStreamHandlerFactory(new MockURLStreamHandlerFactory(urlConnection));
+        IOException exception = mock(IOException.class);
+        when(urlConnection.getInputStream()).thenThrow(exception);
+
+        UrlJwkProvider urlJwkProvider = new UrlJwkProvider(new URL("mock://localhost"));
+        urlJwkProvider.get("NkJCQzIyQzRBMEU4NjhGNUU4MzU4RkY0M0ZDQzkwOUQ0Q0VGNUMwQg");
+    }
 }


### PR DESCRIPTION
### Changes

Rebasing thomsonreuters fork with latest changes from auth0

### References

https://github.com/auth0/jwks-rsa-java/pull/91

### Testing

Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors. 

- [X] This change adds test coverage
- [X] This change has been tested on the latest version of Java or why not

### Checklist

- [X] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [X] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [X] All existing and new tests complete without errors
